### PR TITLE
Basic setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(
+    name="isophote",
+    url="https://github.com/ibusko/isophote",
+    packages=["ellipse"],
+# Doesn't work because of relative paths to test/data in test/test_*.py:
+#    test_suite="test",
+)


### PR DESCRIPTION
I added basic `setup.py` for easy installation of the package.

`setup()` argument `test_suite` is commented. If uncomment it and do `python setup.py test` then tests run, but fail because of relative paths to `test/data` folder.